### PR TITLE
Allow longer filenames in crate assembler

### DIFF
--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -25,7 +25,7 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "812da3752022e7f1529b1e445c38fb8b11239c56", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "d76a7b935cd6452615f78772539fbc2e1228f503", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )
 
 def vaticle_typedb_common():


### PR DESCRIPTION
## What is the goal of this PR?

The `deploy-crate-snapshot` task in CI fails because a newly introduced module pushed the path length to being just over 100 bytes, triggering the following error:
```
Action assemble_crate.crate failed: (Exit 1): crate-assembler failed: error executing command bazel-out/host/bin/external/vaticle_bazel_distribution/crates/crate-assembler --srcs ... (remaining 29 arguments skipped)

java.lang.IllegalArgumentException: file name 'typedb-client-0.0.0-d56ec4d4e590db3db79ef42118e1cb9aee86329d/src/connection/cluster/database_manager.rs' is too long ( > 100 bytes)
```

This issue was fixed by switching to the POSIX tar headers in bazel-distribution. This PR propagates this change via dependencies into client-rust.

## What are the changes implemented in this PR?

We update the vaticle dependencies to point at the version with the updated `assemble_crate` rule.