### PR TITLE
Fix parse errors handling in BDD

### DIFF
--- a/tests/BUILD
+++ b/tests/BUILD
@@ -38,6 +38,7 @@ rust_test(
         "@crates//:serial_test",
         "@crates//:smol",
         "@crates//:tokio",
+        "@vaticle_typeql//rust:typeql_lang",
     ],
     data = [
         "@vaticle_typedb_behaviour//connection:database.feature",

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -31,6 +31,7 @@ rust_test(
     srcs = glob(["**/*.rs"]),
     deps = [
         "//:typedb_client",
+        "@vaticle_typeql//rust:typeql_lang",
         "@crates//:async-std",
         "@crates//:chrono",
         "@crates//:cucumber",
@@ -38,7 +39,6 @@ rust_test(
         "@crates//:serial_test",
         "@crates//:smol",
         "@crates//:tokio",
-        "@vaticle_typeql//rust:typeql_lang",
     ],
     data = [
         "@vaticle_typedb_behaviour//connection:database.feature",

--- a/tests/behaviour/typeql/steps.rs
+++ b/tests/behaviour/typeql/steps.rs
@@ -83,14 +83,14 @@ generic_step_impl! {
         let parsed = parse_query(step.docstring().unwrap());
         if parsed.is_ok() {
             let stream = context.transaction().query().insert(&parsed.unwrap().to_string());
-            if stream.is_ok() {
-                let res = stream.unwrap().try_collect::<Vec<_>>().await;
-                assert!(res.is_err());
-                assert!(res.map(|_| ()).unwrap_err().to_string().contains(&exception));
+            match stream {
+                Ok(unwraped) => {
+                    let res = unwraped.try_collect::<Vec<_>>().await;
+                    assert!(res.is_err());
+                    assert!(res.map(|_| ()).unwrap_err().to_string().contains(&exception));
+                },
+                Err(error) => assert!(error.to_string().contains(&exception)),
             }
-            // else {
-            //     assert!(stream.unwrap_err().to_string().contains(&exception));
-            // }
         }
         else {
             assert!(parsed.unwrap_err().to_string().contains(&exception));

--- a/tests/behaviour/typeql/steps.rs
+++ b/tests/behaviour/typeql/steps.rs
@@ -82,8 +82,7 @@ generic_step_impl! {
     async fn typeql_insert_throws_exception(context: &mut Context, step: &Step, exception: String) {
         let parsed = parse_query(step.docstring().unwrap());
         if parsed.is_ok() {
-            let stream = context.transaction().query().insert(&parsed.unwrap().to_string());
-            match stream {
+            match context.transaction().query().insert(&parsed.unwrap().to_string()) {
                 Ok(unwraped) => {
                     let res = unwraped.try_collect::<Vec<_>>().await;
                     assert!(res.is_err());

--- a/tests/behaviour/typeql/steps.rs
+++ b/tests/behaviour/typeql/steps.rs
@@ -58,9 +58,9 @@ generic_step_impl! {
     async fn typeql_insert(context: &mut Context, step: &Step) {
         let parsed = parse_query(step.docstring().unwrap());
         assert!(parsed.is_ok());
-        let stream = context.transaction().query().insert(&parsed.unwrap().to_string());
-        assert!(stream.is_ok());
-        let res = stream.unwrap().try_collect::<Vec<_>>().await;
+        let inserted = context.transaction().query().insert(&parsed.unwrap().to_string());
+        assert!(inserted.is_ok());
+        let res = inserted.unwrap().try_collect::<Vec<_>>().await;
         assert!(res.is_ok());
     }
 
@@ -68,9 +68,9 @@ generic_step_impl! {
     async fn typeql_insert_throws(context: &mut Context, step: &Step) {
         let parsed = parse_query(step.docstring().unwrap());
         if parsed.is_ok() {
-            let stream = context.transaction().query().insert(&parsed.unwrap().to_string());
-            if stream.is_ok() {
-                let res = stream.unwrap().try_collect::<Vec<_>>().await;
+            let inserted = context.transaction().query().insert(&parsed.unwrap().to_string());
+            if inserted.is_ok() {
+                let res = inserted.unwrap().try_collect::<Vec<_>>().await;
                 assert!(res.is_err());
             }
         }
@@ -83,7 +83,7 @@ generic_step_impl! {
                 context.transaction().query().insert(&parsed.to_string()).map_err(|error| error.to_string())
             })
         }
-        .and_then(|stream| async { stream.try_collect::<Vec<_>>().await.map_err(|error| error.to_string()) })
+        .and_then(|inserted| async { inserted.try_collect::<Vec<_>>().await.map_err(|error| error.to_string()) })
         .await;
         assert!(result.is_err());
         assert!(result.unwrap_err().contains(&exception));

--- a/tests/behaviour/typeql/steps.rs
+++ b/tests/behaviour/typeql/steps.rs
@@ -21,48 +21,79 @@
 
 use cucumber::{gherkin::Step, given, then, when};
 use futures::TryStreamExt;
+use typeql_lang::parse_query;
 
 use crate::{behaviour::Context, generic_step_impl};
 
 generic_step_impl! {
     #[step(expr = "typeql define")]
     async fn typeql_define(context: &mut Context, step: &Step) {
-        // FIXME parse
-        context.transaction().query().define(step.docstring().unwrap()).await.unwrap();
+        let parsed = parse_query(step.docstring().unwrap());
+        assert!(parsed.is_ok());
+        let res = context.transaction().query().define(&parsed.unwrap().to_string()).await;
+        assert!(res.is_ok());
     }
 
     #[step(expr = "typeql define; throws exception")]
     async fn typeql_define_throws(context: &mut Context, step: &Step) {
-        // FIXME parse
-        assert!(context.transaction().query().define(step.docstring().unwrap()).await.is_err());
+        let parsed = parse_query(step.docstring().unwrap());
+        if parsed.is_ok() {
+            let res = context.transaction().query().define(&parsed.unwrap().to_string()).await;
+            assert!(res.is_err());
+        }
     }
 
     #[step(expr = "typeql define; throws exception containing {string}")]
     async fn typeql_define_throws_exception(context: &mut Context, step: &Step, exception: String) {
-        // FIXME parse
-        let res = context.transaction().query().define(step.docstring().unwrap()).await;
-        assert!(res.is_err());
-        assert!(res.unwrap_err().to_string().contains(&exception));
+        let parsed = parse_query(step.docstring().unwrap());
+        if parsed.is_ok() {
+            let res = context.transaction().query().define(&parsed.unwrap().to_string()).await;
+            assert!(res.is_err());
+            assert!(res.unwrap_err().to_string().contains(&exception));
+        }
+        else {
+            assert!(parsed.unwrap_err().to_string().contains(&exception));
+        }
     }
 
     #[step(expr = "typeql insert")]
     async fn typeql_insert(context: &mut Context, step: &Step) {
-        // FIXME parse
-        let stream = context.transaction().query().insert(step.docstring().unwrap()).unwrap();
-        stream.try_collect::<Vec<_>>().await.unwrap();
+        let parsed = parse_query(step.docstring().unwrap());
+        assert!(parsed.is_ok());
+        let stream = context.transaction().query().insert(&parsed.unwrap().to_string());
+        assert!(stream.is_ok());
+        let res = stream.unwrap().try_collect::<Vec<_>>().await;
+        assert!(res.is_ok());
     }
 
     #[step(expr = "typeql insert; throws exception")]
     async fn typeql_insert_throws(context: &mut Context, step: &Step) {
-        // FIXME parse
-        assert!(context.transaction().query().insert(step.docstring().unwrap()).is_err());
+        let parsed = parse_query(step.docstring().unwrap());
+        if parsed.is_ok() {
+            let stream = context.transaction().query().insert(&parsed.unwrap().to_string());
+            if stream.is_ok() {
+                let res = stream.unwrap().try_collect::<Vec<_>>().await;
+                assert!(res.is_err());
+            }
+        }
     }
 
     #[step(expr = "typeql insert; throws exception containing {string}")]
     async fn typeql_insert_throws_exception(context: &mut Context, step: &Step, exception: String) {
-        // FIXME parse
-        let res = context.transaction().query().insert(step.docstring().unwrap()).unwrap().try_collect::<Vec<_>>().await;
-        assert!(res.is_err());
-        assert!(res.map(|_| ()).unwrap_err().to_string().contains(&exception));
+        let parsed = parse_query(step.docstring().unwrap());
+        if parsed.is_ok() {
+            let stream = context.transaction().query().insert(&parsed.unwrap().to_string());
+            if stream.is_ok() {
+                let res = stream.unwrap().try_collect::<Vec<_>>().await;
+                assert!(res.is_err());
+                assert!(res.map(|_| ()).unwrap_err().to_string().contains(&exception));
+            }
+            // else {
+            //     assert!(stream.unwrap_err().to_string().contains(&exception));
+            // }
+        }
+        else {
+            assert!(parsed.unwrap_err().to_string().contains(&exception));
+        }
     }
 }

--- a/tests/behaviour/typeql/steps.rs
+++ b/tests/behaviour/typeql/steps.rs
@@ -45,13 +45,11 @@ generic_step_impl! {
 
     #[step(expr = "typeql define; throws exception containing {string}")]
     async fn typeql_define_throws_exception(context: &mut Context, step: &Step, exception: String) {
-        let result = async {
-            parse_query(step.docstring().unwrap())
-            .map_err(|error| error.to_string())
-        }
-        .and_then(|parsed| async move {context.transaction().query().define(&parsed.to_string()).await
-            .map_err(|error| error.to_string())
-        }).await;
+        let result = async { parse_query(step.docstring().unwrap()).map_err(|error| error.to_string()) }
+            .and_then(|parsed| async move {
+                context.transaction().query().define(&parsed.to_string()).await.map_err(|error| error.to_string())
+            })
+            .await;
         assert!(result.is_err());
         assert!(result.unwrap_err().contains(&exception));
     }
@@ -81,15 +79,12 @@ generic_step_impl! {
     #[step(expr = "typeql insert; throws exception containing {string}")]
     async fn typeql_insert_throws_exception(context: &mut Context, step: &Step, exception: String) {
         let result = async {
-            parse_query(step.docstring().unwrap())
-            .map_err(|error| error.to_string())
-            .and_then(|parsed| context.transaction().query().insert(&parsed.to_string())
-                .map_err(|error| error.to_string())
-            )
+            parse_query(step.docstring().unwrap()).map_err(|error| error.to_string()).and_then(|parsed| {
+                context.transaction().query().insert(&parsed.to_string()).map_err(|error| error.to_string())
+            })
         }
-        .and_then(|stream| async {stream.try_collect::<Vec<_>>().await
-            .map_err(|error| error.to_string())
-        }).await;
+        .and_then(|stream| async { stream.try_collect::<Vec<_>>().await.map_err(|error| error.to_string()) })
+        .await;
         assert!(result.is_err());
         assert!(result.unwrap_err().contains(&exception));
     }


### PR DESCRIPTION
## What is the goal of this PR?

We improved parse errors handling in the `behaviour` test package.

## What are the changes implemented in this PR?

We added asserts at the all stages of query processing for "`typeql define [...]`" and "`typeql insert [...]`" expressions.
