### PR TITLE
Made datetime attribute insert and match time-zone invariant

### DIFF
--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -45,8 +45,8 @@ def vaticle_typedb_protocol():
 def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "d4947828f570853b71f0eb8aefd34af7b5a485fb", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/shiladitya-mukherjee/typedb-behaviour",
+        commit = "c7d2aeff49e1537f11c3895f22e6c8056ea6f601" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
 
 def vaticle_typeql():

--- a/tests/behaviour/typeql/language/steps.rs
+++ b/tests/behaviour/typeql/language/steps.rs
@@ -27,6 +27,7 @@ use util::{
     equals_approximate, iter_table_map, match_answer_concept, match_answer_concept_map, match_answer_rule,
     match_templated_answer,
 };
+use std::env;
 
 use crate::{
     assert_err,
@@ -399,5 +400,10 @@ generic_step_impl! {
             "An identifier entry (row) should match 1-to-1 to an answer, but there are only {matched_rows} \
             matched entries of given {actual_answers}."
         );
+    }
+
+    #[step(expr = "set time-zone is: {word}")]
+    async fn time_zone_info(context: &mut Context, timezone: String) {
+        env::set_var("TZ", timezone);
     }
 }

--- a/tests/behaviour/util.rs
+++ b/tests/behaviour/util.rs
@@ -135,7 +135,12 @@ fn value_equals_str(value: &Value, expected: &str) -> bool {
             expected.parse::<bool>().and_then(|expected| Ok(expected.eq(val))).unwrap_or_else(|_| false)
         }
         Value::DateTime(val) => {
-            return val == &NaiveDateTime::parse_from_str(expected, "%Y-%m-%dT%H:%M:%S").unwrap();
+            if expected.contains(":") {
+                val == &NaiveDateTime::parse_from_str(expected, "%Y-%m-%dT%H:%M:%S").unwrap();
+            }
+            else {
+                val == &NaiveDateTime::parse_from_str(expected, "%Y-%m-%d").unwrap();
+            }
         }
     }
 }

--- a/tests/behaviour/util.rs
+++ b/tests/behaviour/util.rs
@@ -67,6 +67,7 @@ pub async fn match_answer_concept(context: &Context, answer_identifier: &str, an
         "key" => key_values_equal(context, identifiers[1], answer).await,
         "label" => labels_equal(identifiers[1], answer),
         "value" => values_equal(identifiers[1], answer),
+        "attr" => values_equal(identifiers[1], answer),
         _ => unreachable!(),
     }
 }
@@ -133,21 +134,15 @@ fn value_equals_str(value: &Value, expected: &str) -> bool {
         Value::Boolean(val) => {
             expected.parse::<bool>().and_then(|expected| Ok(expected.eq(val))).unwrap_or_else(|_| false)
         }
-        Value::DateTime(val) => format_datetime(val) == expected,
+        Value::DateTime(val) => {
+            return val == &NaiveDateTime::parse_from_str(expected, "%Y-%m-%dT%H:%M:%S").unwrap();
+        }
     }
 }
 
 pub fn equals_approximate(first: f64, second: f64) -> bool {
     const EPS: f64 = 1e-4;
     return (first - second).abs() < EPS;
-}
-
-fn format_datetime(datetime: &NaiveDateTime) -> String {
-    if datetime.time() == NaiveTime::from_hms_opt(0, 0, 0).unwrap() {
-        format!("{0}", datetime.date())
-    } else {
-        format!("{0}", datetime)
-    }
 }
 
 pub async fn match_templated_answer(


### PR DESCRIPTION
## What is the goal of this PR?

Made datetime attribute insert and match time-zone invariant

## What are the changes implemented in this PR?

- Added "set time-zone is: {time_zone_label}" which sets environment timezone to time_zone_label.
- Fixed datetime parsing bug in util.